### PR TITLE
Ignore ADMM auxiliary basis in CP2K input parser

### DIFF
--- a/cp2k_spm_tools/cp2k_grid_orbitals.py
+++ b/cp2k_spm_tools/cp2k_grid_orbitals.py
@@ -21,6 +21,12 @@ from .cube import Cube
 ang_2_bohr = 1.88972612463
 hart_2_ev = 27.21138602
 
+AUXILIARY_BASIS_SET_TYPES = {"AUX_FIT", "RI_AUX"}
+
+
+def is_auxiliary_basis_set_line(parts):
+    return len(parts) > 2 and parts[0].upper() == "BASIS_SET" and parts[1].upper() in AUXILIARY_BASIS_SET_TYPES
+
 
 class Cp2kGridOrbitals:
     """
@@ -114,10 +120,10 @@ class Cp2kGridOrbitals:
                             else:
                                 subsec_count -= 1
                         parts = line.split()
-                        if parts[0] == "ELEMENT":
+                        if parts[0].upper() == "ELEMENT":
                             elem = parts[1]
-                        if parts[0] == "BASIS_SET":
-                            if len(parts) > 2 and parts[1].upper() in {"AUX_FIT", "RI_AUX"}:
+                        if parts[0].upper() == "BASIS_SET":
+                            if is_auxiliary_basis_set_line(parts):
                                 continue
                             basis_name = parts[1]
                     ## ---------------------------------------------------------------------

--- a/cp2k_spm_tools/cp2k_grid_orbitals.py
+++ b/cp2k_spm_tools/cp2k_grid_orbitals.py
@@ -117,6 +117,8 @@ class Cp2kGridOrbitals:
                         if parts[0] == "ELEMENT":
                             elem = parts[1]
                         if parts[0] == "BASIS_SET":
+                            if len(parts) > 2 and parts[1].upper() in {"AUX_FIT", "RI_AUX"}:
+                                continue
                             basis_name = parts[1]
                     ## ---------------------------------------------------------------------
                     if elem is None:


### PR DESCRIPTION
This pull request makes a targeted update to the `read_cp2k_input` function in `cp2k_grid_orbitals.py` to improve how auxiliary basis sets are handled. The main change ensures that lines specifying auxiliary basis sets, such as `AUX_FIT` or `RI_AUX`, are skipped during parsing, preventing them from being incorrectly treated as main orbital basis sets.

## Context

CP2K inputs using ADMM/hybrid functionals can contain multiple `BASIS_SET` lines inside one `&KIND` section, for example:

```text
BASIS_SET TZVP-MOLOPT-PBE0-GTH-q4
BASIS_SET AUX_FIT admm-tzp-q4
```

The parser previously treated the auxiliary `AUX_FIT` / `RI_AUX` line as the main orbital basis. This could make tools fail later with missing basis data, for example `KeyError: 'C'`, because the code tried to read a basis named `AUX_FIT`.

## Scope

This fixes the central `Cp2kGridOrbitals.read_cp2k_input()` parser used by:

- `cp2k-overlap-from-wfns`
- `cp2k-stm-sts-wfn`
- `cp2k-hrstm-from-wfn`
- `cp2k-cube-from-wfn`

The parser now ignores auxiliary basis declarations and keeps the primary orbital basis. The check is case-insensitive and robust to extra whitespace.

## Verification

Tested with representative CP2K `&KIND` snippets containing:

- `BASIS_SET AUX_FIT ...`
- `BASIS_SET RI_AUX ...`
- lowercase/mixed-case keywords
- extra whitespace before and between tokens

Also tested in a local ADMM/PBE0 workflow where the real CP2K input contains `BASIS_SET AUX_FIT ...`; the overlap post-processing no longer fails with a missing-kind/basis lookup error.
