### PR TITLE
Allow NumPy 2

### DIFF
--- a/cp2k_spm_tools/qe_utils.py
+++ b/cp2k_spm_tools/qe_utils.py
@@ -239,7 +239,7 @@ def read_atomic_proj(atomic_proj_xml):
 
     projections_node = data_file_root.find("PROJECTIONS")
 
-    wfc_projs = np.zeros((n_spin, n_kpts, n_at_wfc, n_bands), dtype=np.complex)
+    wfc_projs = np.zeros((n_spin, n_kpts, n_at_wfc, n_bands), dtype=complex)
     for i_kpt in range(n_kpts):
         for i_spin in range(n_spin):
             for i_wfc in range(n_at_wfc):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "numpy >= 1.22, < 2",
+    "numpy >= 1.22, < 3",
     "scipy >= 1.10, < 2",
     "ase >= 3.15, < 4",
     "matplotlib >= 3.0, < 4",


### PR DESCRIPTION
## Summary
- allow NumPy 2 in the package metadata
- replace the removed np.complex alias with the builtin complex type

## Motivation
This keeps cp2k-spm-tools installable in Python 3.12 environments that already use NumPy 2. The removed np.complex alias is the only obvious NumPy 2 incompatibility found in the package code.

## Tests
- python -c "import cp2k_spm_tools, numpy; print('cp2k_spm_tools ok'); print(numpy.__version__)"
- verified in the AiiDAlab instance with NumPy 2.5.0