### PR TITLE
Support skewed in-plane SPM cells

### DIFF
--- a/cp2k_spm_tools/cli/stm_sts_from_wfn.py
+++ b/cp2k_spm_tools/cli/stm_sts_from_wfn.py
@@ -242,30 +242,34 @@ def main():
     time1 = time.time()
 
     ### ------------------------------------------------------
-    ### Calculate the ionization potential (just for output)
-    ### ------------------------------------------------------
-
-    if mpi_rank == 0:
-        # NB: currently only accurate for isolated molecules
-        if cp2k_grid_orb.nspin == 1:
-            homo_en = cp2k_grid_orb.global_morb_energies[0][cp2k_grid_orb.i_homo_glob[0]]
-        else:
-            homo_en = np.max(
-                [
-                    cp2k_grid_orb.global_morb_energies[0][cp2k_grid_orb.i_homo_glob[0]],
-                    cp2k_grid_orb.global_morb_energies[1][cp2k_grid_orb.i_homo_glob[1]],
-                ]
-            )
-        ion_pot = cube_utils.find_vacuum_level_naive(hart_cube) - (homo_en + cp2k_grid_orb.ref_energy)
-        print("IONIZATION POTENIAL (eV): %.6f (accurate only for isolated molecules)" % ion_pot)
-        sys.stdout.flush()
-
-    ### ------------------------------------------------------
     ### Set up STM object
     ### ------------------------------------------------------
 
     stm = css.STM(mpi_comm=comm, cp2k_grid_orb=cp2k_grid_orb, p_tip_ratios=args.p_tip_ratios)
     stm.gather_global_energies()
+
+    ### ------------------------------------------------------
+    ### Calculate the ionization potential (just for output)
+    ### ------------------------------------------------------
+
+    if mpi_rank == 0:
+        # NB: currently only accurate for isolated molecules. This estimate is
+        # optional because the selected STM energy window may not include the HOMO.
+        homo_energies = []
+        for ispin in range(cp2k_grid_orb.nspin):
+            homo_index = cp2k_grid_orb.i_homo_glob[ispin]
+            spin_energies = stm.global_morb_energies[ispin]
+            if 0 <= homo_index < len(spin_energies):
+                homo_energies.append(spin_energies[homo_index])
+
+        if homo_energies:
+            homo_en = np.max(homo_energies)
+            ion_pot = cube_utils.find_vacuum_level_naive(hart_cube) - (homo_en + cp2k_grid_orb.ref_energy)
+            print("IONIZATION POTENIAL (eV): %.6f (accurate only for isolated molecules)" % ion_pot)
+        else:
+            print("Skipping ionization potential estimate: HOMO is outside the selected orbital window.")
+        sys.stdout.flush()
+
     stm.divide_by_space()
 
     ### ------------------------------------------------------

--- a/cp2k_spm_tools/cli/stm_sts_from_wfn.py
+++ b/cp2k_spm_tools/cli/stm_sts_from_wfn.py
@@ -264,8 +264,13 @@ def main():
 
         if homo_energies:
             homo_en = np.max(homo_energies)
-            ion_pot = cube_utils.find_vacuum_level_naive(hart_cube) - (homo_en + cp2k_grid_orb.ref_energy)
-            print("IONIZATION POTENIAL (eV): %.6f (accurate only for isolated molecules)" % ion_pot)
+            try:
+                vacuum_level = cube_utils.find_vacuum_level_naive(hart_cube)
+            except ValueError as exc:
+                print(f"Skipping ionization potential estimate: {exc}")
+            else:
+                ion_pot = vacuum_level - (homo_en + cp2k_grid_orb.ref_energy)
+                print("IONIZATION POTENIAL (eV): %.6f (accurate only for isolated molecules)" % ion_pot)
         else:
             print("Skipping ionization potential estimate: HOMO is outside the selected orbital window.")
         sys.stdout.flush()

--- a/cp2k_spm_tools/cp2k_grid_orbitals.py
+++ b/cp2k_spm_tools/cp2k_grid_orbitals.py
@@ -45,7 +45,8 @@ class Cp2kGridOrbitals:
             self.dtype = np.float64
 
         # geometry
-        self.cell = None  # Bohr radii / [au]
+        self.cell = None  # lattice vector lengths in Bohr radii / [au]
+        self.cell_vectors = None  # lattice vectors in Bohr radii / [au]
         self.ase_atoms = None
         self.atom_kinds = None  # saves the kind for each atom
 
@@ -71,9 +72,11 @@ class Cp2kGridOrbitals:
 
         # Orbitals on discrete grid
         self.morb_grids = None
-        self.dv = None  # [dx, dy, dz] in [au]
+        self.dv = None  # grid step vector lengths [dx, dy, dz] in [au]
+        self.dv_vectors = None  # grid step vectors in [au]
         self.origin = None  # origin point of the evaluation grid
         self.eval_cell = None
+        self.eval_cell_vectors = None
         self.eval_cell_n = None
 
         self.last_calc_iz = None  # last directly calculated z plane (others extrapolated)
@@ -81,6 +84,88 @@ class Cp2kGridOrbitals:
     @property
     def cell_ang(self):
         return self.cell / ang_2_bohr
+
+    @property
+    def cell_vectors_ang(self):
+        return self.cell_vectors / ang_2_bohr
+
+    @property
+    def eval_cell_vectors_ang(self):
+        return self.eval_cell_vectors / ang_2_bohr
+
+    def _cell_unit_vectors(self):
+        return self.cell_vectors / self.cell[:, None]
+
+    def _is_in_plane_orthogonal_cell(self, tol=1e-10):
+        return abs(np.dot(self.cell_vectors[0], self.cell_vectors[1])) < tol * self.cell[0] * self.cell[1]
+
+    def _is_supported_skewed_surface_cell(self, tol=1e-10):
+        return (
+            abs(self.cell_vectors[0, 2]) < tol * self.cell[0]
+            and abs(self.cell_vectors[1, 2]) < tol * self.cell[1]
+            and np.linalg.norm(self.cell_vectors[2, :2]) < tol * self.cell[2]
+        )
+
+    def _cartesian_to_fractional(self, coord):
+        return np.asarray(coord) @ np.linalg.inv(self.cell_vectors)
+
+    def _cartesian_to_grid(self, coord, grid_n):
+        return self._cartesian_to_fractional(coord) * grid_n
+
+    def _update_grid_vectors_from_lengths(self):
+        self.dv_vectors = self._cell_unit_vectors() * self.dv[:, None]
+        self.eval_cell_vectors = self.dv_vectors * self.eval_cell_n[:, None]
+        self.eval_cell = self.eval_cell_n * self.dv
+
+    def _eval_cell_matrix(self):
+        if self.eval_cell_vectors is None:
+            return self.eval_cell * np.eye(3)
+        return self.eval_cell_vectors
+
+    def _voxel_volume(self):
+        if self.dv_vectors is None:
+            return np.prod(self.dv)
+        return abs(np.linalg.det(self.dv_vectors))
+
+    def _surface_reciprocal_grids(self, shape):
+        a_vec = self.dv_vectors[0] * shape[0]
+        b_vec = self.dv_vectors[1] * shape[1]
+        normal = np.cross(a_vec, b_vec)
+        normal_norm_sq = np.dot(normal, normal)
+        if normal_norm_sq < 1e-20:
+            raise ValueError("Cannot build reciprocal grid for a degenerate surface cell.")
+
+        b1 = 2 * np.pi * np.cross(b_vec, normal) / normal_norm_sq
+        b2 = 2 * np.pi * np.cross(normal, a_vec) / normal_norm_sq
+
+        m_arr = np.fft.fftfreq(shape[0]) * shape[0]
+        n_arr = np.fft.rfftfreq(shape[1]) * shape[1]
+        m_grid, n_grid = np.meshgrid(m_arr, n_arr, indexing="ij")
+
+        g_vec = m_grid[..., None] * b1 + n_grid[..., None] * b2
+        return np.sum(g_vec**2, axis=-1)
+
+    def _extrapolation_step_length(self):
+        normal = np.cross(self.dv_vectors[0], self.dv_vectors[1])
+        normal /= np.linalg.norm(normal)
+        dz = abs(np.dot(self.dv_vectors[2], normal))
+        if dz < 1e-12:
+            raise ValueError("The extrapolation direction is parallel to the surface plane.")
+        return dz
+
+    @staticmethod
+    def _parse_cell_vector_parts(parts):
+        values = parts[1:]
+        unit = "angstrom"
+        if values and values[0].startswith("["):
+            unit = values[0].strip("[]").lower()
+            values = values[1:]
+        vector = np.array([float(x) for x in values[:3]])
+        if unit in {"angstrom", "ang"}:
+            return vector
+        if unit in {"bohr", "au", "a.u."}:
+            return vector / ang_2_bohr
+        raise ValueError(f"Unsupported CP2K cell vector unit: {unit}")
 
     ### -----------------------------------------
     ### General cp2k routines
@@ -93,7 +178,7 @@ class Cp2kGridOrbitals:
         * Cell size
         """
         self.kind_elem_basis = {}
-        self.cell = np.zeros(3)
+        self.cell_vectors = np.zeros((3, 3))
         with open(cp2k_input_file) as f:
             lines = f.readlines()
             for i in range(len(lines)):
@@ -146,29 +231,20 @@ class Cp2kGridOrbitals:
 
                 # Have we found the CELL info?
                 if parts[0] == "ABC":
-                    if parts[1] == "[angstrom]":
-                        self.cell[0] = float(parts[2])
-                        self.cell[1] = float(parts[3])
-                        self.cell[2] = float(parts[4])
-                    else:
-                        self.cell[0] = float(parts[1])
-                        self.cell[1] = float(parts[2])
-                        self.cell[2] = float(parts[3])
+                    self.cell_vectors = np.diag(self._parse_cell_vector_parts(parts))
 
                 if parts[0] == "A" or parts[0] == "B" or parts[0] == "C":
-                    prim_vec = np.array([float(x) for x in parts[1:]])
-                    if np.sum(prim_vec > 0.0) > 1:
-                        raise ValueError("Cell is not rectangular")
-                    ind = np.argmax(prim_vec > 0.0)
-                    self.cell[ind] = prim_vec[ind]
+                    ind = {"A": 0, "B": 1, "C": 2}[parts[0]]
+                    self.cell_vectors[ind] = self._parse_cell_vector_parts(parts)
 
-        self.cell *= ang_2_bohr
+        self.cell_vectors *= ang_2_bohr
+        self.cell = np.linalg.norm(self.cell_vectors, axis=1)
 
         if any(self.cell < 1e-3):
-            raise ValueError("Cell " + str(self.cell) + " is invalid")
+            raise ValueError("Cell " + str(self.cell_vectors) + " is invalid")
 
         if self.ase_atoms is not None:
-            self.ase_atoms.cell = self.cell / ang_2_bohr
+            self.ase_atoms.cell = self.cell_vectors / ang_2_bohr
 
     def read_xyz(self, file_xyz):
         """Read atomic positions from .xyz file (in Bohr radiuses)"""
@@ -186,7 +262,7 @@ class Cp2kGridOrbitals:
         self.ase_atoms = ase.io.read(io.StringIO("".join(fxyz_contents)), format="xyz")
 
         if self.cell is not None:
-            self.ase_atoms.cell = self.cell / ang_2_bohr
+            self.ase_atoms.cell = self.cell_vectors / ang_2_bohr
 
     def center_atoms_to_cell(self):
         self.ase_atoms.center()
@@ -603,8 +679,19 @@ class Cp2kGridOrbitals:
         eval_regions_ang = [x_eval_region, y_eval_region, z_eval_region]
         eval_regions = [np.array(er) * ang_2_bohr if er is not None else er for er in eval_regions_ang]
 
+        if not self._is_in_plane_orthogonal_cell() and any(er is not None for er in eval_regions[:2]):
+            raise NotImplementedError(
+                "Custom x/y evaluation regions are not supported for non-orthogonal in-plane cells. "
+                "Use the full periodic surface cell in x/y."
+            )
+        if not self._is_in_plane_orthogonal_cell() and not self._is_supported_skewed_surface_cell():
+            raise NotImplementedError(
+                "Non-orthogonal cells are supported only for slab cells with A/B in the xy plane and C along z."
+            )
+
         global_cell_n = (np.round(self.cell / dr_guess)).astype(int)
         self.dv = self.cell / global_cell_n
+        self.dv_vectors = self.cell_vectors / global_cell_n[:, None]
 
         ### ----------------------------------------
         ### Define evaluation grid
@@ -633,7 +720,7 @@ class Cp2kGridOrbitals:
         self.last_calc_iz = self.eval_cell_n[2] - 1
         ext_z_n = int(np.round(reserve_extrap / self.dv[2]))
         self.eval_cell_n[2] += ext_z_n
-        self.eval_cell = self.eval_cell_n * self.dv
+        self._update_grid_vectors_from_lengths()
 
         ### ----------------------------------------
         ### Local evaluation grid around each atom
@@ -706,19 +793,39 @@ class Cp2kGridOrbitals:
             pos = self.ase_atoms[i_at].position * ang_2_bohr
 
             # how does the position match with the grid?
-            int_shift = (pos / self.dv).astype(int)
-            frac_shift = pos / self.dv - int_shift
+            atom_grid_pos = self._cartesian_to_grid(pos, global_cell_n)
+            int_shift = np.floor(atom_grid_pos).astype(int)
+            frac_shift = atom_grid_pos - int_shift
             origin_diff = int_shift - mid_ixs
 
-            # Shift the local grid coordinates such that (0,0,0) is the atom
-            rel_loc_cell_grids = []
+            # Shift the local grid coordinates such that (0,0,0) is the atom.
+            # The local arrays are lattice-axis distances; convert them to Cartesian
+            # coordinates before evaluating solid harmonics and radial functions.
+            rel_loc_axis_grids = []
             for i, loc_grid in enumerate(loc_cell_grids):
                 if pbc[i]:
-                    rel_loc_cell_grids.append(loc_grid - frac_shift[i] * self.dv[i])
+                    rel_loc_axis_grids.append(loc_grid - frac_shift[i] * self.dv[i])
                 else:
-                    rel_loc_cell_grids.append(loc_grid - pos[i])
+                    rel_loc_axis_grids.append(loc_grid - pos[i])
 
-            r_vec_2 = rel_loc_cell_grids[0] ** 2 + rel_loc_cell_grids[1] ** 2 + rel_loc_cell_grids[2] ** 2
+            unit_vectors = self._cell_unit_vectors()
+            rel_x = (
+                rel_loc_axis_grids[0] * unit_vectors[0, 0]
+                + rel_loc_axis_grids[1] * unit_vectors[1, 0]
+                + rel_loc_axis_grids[2] * unit_vectors[2, 0]
+            )
+            rel_y = (
+                rel_loc_axis_grids[0] * unit_vectors[0, 1]
+                + rel_loc_axis_grids[1] * unit_vectors[1, 1]
+                + rel_loc_axis_grids[2] * unit_vectors[2, 1]
+            )
+            rel_z = (
+                rel_loc_axis_grids[0] * unit_vectors[0, 2]
+                + rel_loc_axis_grids[1] * unit_vectors[1, 2]
+                + rel_loc_axis_grids[2] * unit_vectors[2, 2]
+            )
+
+            r_vec_2 = rel_x**2 + rel_y**2 + rel_z**2
 
             for i_spin in range(nspin):
                 morb_grids_local[i_spin].fill(0.0)
@@ -741,9 +848,9 @@ class Cp2kGridOrbitals:
                         atomic_orb = radial_part * self._spherical_harmonic_grid(
                             l,
                             m,
-                            rel_loc_cell_grids[0],
-                            rel_loc_cell_grids[1],
-                            rel_loc_cell_grids[2],
+                            rel_x,
+                            rel_y,
+                            rel_z,
                         )
                         time_spherical += time.time() - time2
                         time2 = time.time()
@@ -765,7 +872,7 @@ class Cp2kGridOrbitals:
                         self.morb_grids[i_spin][i_mo][:, :, :z_end_ind],
                         global_cell_n,
                         origin_diff,
-                        np.round(self.origin / self.dv).astype(int),
+                        np.round(self._cartesian_to_grid(self.origin, global_cell_n)).astype(int),
                         wrap=pbc,
                     )
             time_loc_glob_add += time.time() - time2
@@ -846,14 +953,12 @@ class Cp2kGridOrbitals:
                 energy = hartree_avg
 
             fourier = np.fft.rfft2(morb_plane)
-            # NB: rfft2 takes REAL fourier transform over last (y) axis and COMPLEX over other (x) axes
-            # dv in BOHR, so k is in 1/bohr
-            kx_arr = 2 * np.pi * np.fft.fftfreq(morb_plane.shape[0], self.dv[0])
-            ky_arr = 2 * np.pi * np.fft.rfftfreq(morb_plane.shape[1], self.dv[1])
-
-            kx_grid, ky_grid = np.meshgrid(kx_arr, ky_arr, indexing="ij")
-
-            prefactors = np.exp(-np.sqrt(kx_grid**2 + ky_grid**2 - 2 * (energy - hartree_avg)) * self.dv[2])
+            # NB: rfft2 takes REAL fourier transform over last (y) axis and COMPLEX over other (x) axes.
+            # The decay depends on |G| from the reciprocal surface metric. For orthogonal
+            # cells this reduces to the old kx**2 + ky**2 expression.
+            g2_grid = self._surface_reciprocal_grids(morb_plane.shape)
+            sqrt_arg = np.maximum(g2_grid - 2 * (energy - hartree_avg), 0.0)
+            prefactors = np.exp(-np.sqrt(sqrt_arg) * self._extrapolation_step_length())
             for iz in range(self.last_calc_iz + 1, self.eval_cell_n[2]):
                 fourier *= prefactors
                 self.morb_grids[ispin][morb_index, :, :, iz] = np.fft.irfft2(fourier, morb_plane.shape)
@@ -879,7 +984,7 @@ class Cp2kGridOrbitals:
                     comment=comment,
                     ase_atoms=self.ase_atoms,
                     origin=self.origin,
-                    cell=self.eval_cell * np.eye(3),
+                    cell=self._eval_cell_matrix(),
                     data=self.morb_grids[spin][local_ind],
                 )
             else:
@@ -888,7 +993,7 @@ class Cp2kGridOrbitals:
                     comment=comment,
                     ase_atoms=self.ase_atoms,
                     origin=self.origin,
-                    cell=self.eval_cell * np.eye(3),
+                    cell=self._eval_cell_matrix(),
                     data=self.morb_grids[spin][local_ind] ** 2,
                 )
             c.write_cube_file(filename)
@@ -907,7 +1012,7 @@ class Cp2kGridOrbitals:
         self.mpi_comm.Reduce(charge_dens, total_charge_dens, op=MPI.SUM)
 
         if self.mpi_rank == 0:
-            vol_elem = np.prod(self.dv)
+            vol_elem = self._voxel_volume()
             integrated_charge = np.sum(total_charge_dens) * vol_elem
             comment = "Integrated charge: %.6f" % integrated_charge
             c = Cube(
@@ -915,7 +1020,7 @@ class Cp2kGridOrbitals:
                 comment=comment,
                 ase_atoms=self.ase_atoms,
                 origin=self.origin,
-                cell=self.eval_cell * np.eye(3),
+                cell=self._eval_cell_matrix(),
                 data=total_charge_dens,
             )
 
@@ -942,7 +1047,7 @@ class Cp2kGridOrbitals:
         self.mpi_comm.Reduce(spin_dens, total_spin_dens, op=MPI.SUM)
 
         if self.mpi_rank == 0:
-            vol_elem = np.prod(self.dv)
+            vol_elem = self._voxel_volume()
             integrated = np.sum(np.abs(total_spin_dens)) * vol_elem
             comment = "Integrated abs spin: %.6f" % integrated
             c = Cube(
@@ -950,7 +1055,7 @@ class Cp2kGridOrbitals:
                 comment=comment,
                 ase_atoms=self.ase_atoms,
                 origin=self.origin,
-                cell=self.eval_cell * np.eye(3),
+                cell=self._eval_cell_matrix(),
                 data=total_spin_dens,
             )
             c.write_cube_file(filename)

--- a/cp2k_spm_tools/cp2k_stm_sts.py
+++ b/cp2k_spm_tools/cp2k_stm_sts.py
@@ -142,16 +142,12 @@ class STM:
                 ### as derivatives are hard to account for after dividing the orbitals in space
                 d_axis0 = np.gradient(self.cgo.morb_grids[ispin], axis=1)
                 d_axis1 = np.gradient(self.cgo.morb_grids[ispin], axis=2)
-                if getattr(self.cgo, "dv_vectors", None) is None:
-                    p_tip_contrib = (d_axis0 / self.dv[0]) ** 2 + (d_axis1 / self.dv[1]) ** 2
-                else:
-                    h_xy = self.cgo.dv_vectors[:2, :2]
-                    if abs(np.linalg.det(h_xy)) < 1e-20:
-                        raise ValueError("Cannot compute p-tip gradients for a degenerate in-plane grid.")
-                    inv_h_xy = np.linalg.inv(h_xy)
-                    grad_x = inv_h_xy[0, 0] * d_axis0 + inv_h_xy[0, 1] * d_axis1
-                    grad_y = inv_h_xy[1, 0] * d_axis0 + inv_h_xy[1, 1] * d_axis1
-                    p_tip_contrib = grad_x**2 + grad_y**2
+                p_tip_contrib = self.in_plane_gradient_squared(
+                    d_axis0,
+                    d_axis1,
+                    self.dv,
+                    getattr(self.cgo, "dv_vectors", None),
+                )
 
                 for rank in range(self.mpi_size):
                     ix_start, ix_end = self.x_ind_per_rank(rank)
@@ -167,6 +163,19 @@ class STM:
                         self.local_orbital_ptip.append(
                             recvbuf.reshape(total_orb, self.local_cell_n[0], self.local_cell_n[1], self.local_cell_n[2])
                         )
+
+    @staticmethod
+    def in_plane_gradient_squared(d_axis0, d_axis1, dv, dv_vectors=None):
+        if dv_vectors is None:
+            return (d_axis0 / dv[0]) ** 2 + (d_axis1 / dv[1]) ** 2
+
+        h_xy = dv_vectors[:2, :2]
+        if abs(np.linalg.det(h_xy)) < 1e-20:
+            raise ValueError("Cannot compute p-tip gradients for a degenerate in-plane grid.")
+        inv_h_xy = np.linalg.inv(h_xy)
+        grad_x = inv_h_xy[0, 0] * d_axis0 + inv_h_xy[0, 1] * d_axis1
+        grad_y = inv_h_xy[1, 0] * d_axis0 + inv_h_xy[1, 1] * d_axis1
+        return grad_x**2 + grad_y**2
 
     def gather_global_energies(self):
         self.global_morb_energies_by_rank = []

--- a/cp2k_spm_tools/cp2k_stm_sts.py
+++ b/cp2k_spm_tools/cp2k_stm_sts.py
@@ -100,9 +100,13 @@ class STM:
         self.local_cell_n = np.array([x_ind_end - x_ind_start, self.cell_n[1], self.cell_n[2]])
         num_spatial_points = (x_ind_end - x_ind_start) * self.cell_n[1] * self.cell_n[2]
 
-        self.local_origin = self.origin
-        self.local_origin[0] += x_ind_start * self.dv[0]
-        self.local_cell = self.local_cell_n * self.dv
+        self.local_origin = self.origin.copy()
+        if getattr(self.cgo, "dv_vectors", None) is not None:
+            self.local_origin += x_ind_start * self.cgo.dv_vectors[0]
+            self.local_cell = self.local_cell_n * self.dv
+        else:
+            self.local_origin[0] += x_ind_start * self.dv[0]
+            self.local_cell = self.local_cell_n * self.dv
 
         for ispin in range(self.nspin):
             orbitals_per_rank = np.array([len(gme) for gme in self.global_morb_energies_by_rank[ispin]])
@@ -136,8 +140,18 @@ class STM:
             if self.ptip_enabled:
                 ### Calculate and divide also the p-tip contribution,
                 ### as derivatives are hard to account for after dividing the orbitals in space
-                p_tip_contrib = (np.gradient(self.cgo.morb_grids[ispin], axis=1) / self.dv[0]) ** 2
-                p_tip_contrib += (np.gradient(self.cgo.morb_grids[ispin], axis=2) / self.dv[1]) ** 2
+                d_axis0 = np.gradient(self.cgo.morb_grids[ispin], axis=1)
+                d_axis1 = np.gradient(self.cgo.morb_grids[ispin], axis=2)
+                if getattr(self.cgo, "dv_vectors", None) is None:
+                    p_tip_contrib = (d_axis0 / self.dv[0]) ** 2 + (d_axis1 / self.dv[1]) ** 2
+                else:
+                    h_xy = self.cgo.dv_vectors[:2, :2]
+                    if abs(np.linalg.det(h_xy)) < 1e-20:
+                        raise ValueError("Cannot compute p-tip gradients for a degenerate in-plane grid.")
+                    inv_h_xy = np.linalg.inv(h_xy)
+                    grad_x = inv_h_xy[0, 0] * d_axis0 + inv_h_xy[0, 1] * d_axis1
+                    grad_y = inv_h_xy[1, 0] * d_axis0 + inv_h_xy[1, 1] * d_axis1
+                    p_tip_contrib = grad_x**2 + grad_y**2
 
                 for rank in range(self.mpi_size):
                     ix_start, ix_end = self.x_ind_per_rank(rank)
@@ -525,6 +539,10 @@ class STM:
             save_data["stm_general_info"]["y_arr"] = (
                 np.arange(0.0, self.cell_n[1] * self.dv[1] + self.dv[1] / 2, self.dv[1]) + self.origin[1]
             )
+            if getattr(self.cgo, "eval_cell_vectors", None) is not None:
+                save_data["stm_general_info"]["origin"] = self.origin
+                save_data["stm_general_info"]["cell_vectors"] = self.cgo.eval_cell_vectors
+                save_data["stm_general_info"]["dv_vectors"] = self.cgo.dv_vectors
             np.savez_compressed(path, **save_data)
 
         # Reset, otherwise can cause problems (more versatile to NOT reset, though)
@@ -683,6 +701,10 @@ class STM:
             save_data["s0_orb_general_info"]["y_arr"] = (
                 np.arange(0.0, self.cell_n[1] * self.dv[1] + self.dv[1] / 2, self.dv[1]) + self.origin[1]
             )
+            if getattr(self.cgo, "eval_cell_vectors", None) is not None:
+                save_data["s0_orb_general_info"]["origin"] = self.origin
+                save_data["s0_orb_general_info"]["cell_vectors"] = self.cgo.eval_cell_vectors
+                save_data["s0_orb_general_info"]["dv_vectors"] = self.cgo.dv_vectors
 
             if "s1_orb" in self.series_output:
                 save_data["s1_orb_general_info"] = self.series_output["s1_orb"]["general_info"]
@@ -696,6 +718,10 @@ class STM:
                 save_data["s1_orb_general_info"]["y_arr"] = (
                     np.arange(0.0, self.cell_n[1] * self.dv[1] + self.dv[1] / 2, self.dv[1]) + self.origin[1]
                 )
+                if getattr(self.cgo, "eval_cell_vectors", None) is not None:
+                    save_data["s1_orb_general_info"]["origin"] = self.origin
+                    save_data["s1_orb_general_info"]["cell_vectors"] = self.cgo.eval_cell_vectors
+                    save_data["s1_orb_general_info"]["dv_vectors"] = self.cgo.dv_vectors
 
             np.savez_compressed(path, **save_data)
 

--- a/examples/validate_skewed_cell_support.py
+++ b/examples/validate_skewed_cell_support.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python
+"""Validate skewed-cell support with bundled benzene CP2K example data.
+
+This is a lightweight regression script for the WFN gridding path. It is meant
+for manual validation before running expensive real CP2K/SPM workflows.
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+from pathlib import Path
+
+import numpy as np
+from scipy.interpolate import RegularGridInterpolator
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from cp2k_spm_tools.cp2k_grid_orbitals import Cp2kGridOrbitals  # noqa: E402
+from cp2k_spm_tools.cube import Cube  # noqa: E402
+
+DATA_DIR = REPO_ROOT / "examples" / "data"
+BENZENE_DIR = DATA_DIR / "benzene_cp2k_scf"
+CP2K_INPUT = BENZENE_DIR / "cp2k.inp"
+XYZ_FILE = BENZENE_DIR / "geom.xyz"
+WFN_FILE = BENZENE_DIR / "PROJ-RESTART.wfn"
+BASIS_FILE = DATA_DIR / "BASIS_MOLOPT"
+
+ORTHOGONAL_CELL_BLOCK = """    &CELL
+      ABC 14.0 14.0 14.0
+    &END CELL
+"""
+SKEWED_CELL_BLOCK = """    &CELL
+      A [angstrom] 14.0 0.0 0.0
+      B [angstrom] 2.0 13.856406460551018 0.0
+      C [angstrom] 0.0 0.0 14.0
+    &END CELL
+"""
+
+
+def make_skewed_input(tmpdir: Path) -> Path:
+    text = CP2K_INPUT.read_text()
+    if ORTHOGONAL_CELL_BLOCK not in text:
+        raise RuntimeError("Could not find the expected benzene CELL block.")
+    skewed_input = tmpdir / "benzene_skewed_cell.inp"
+    skewed_input.write_text(text.replace(ORTHOGONAL_CELL_BLOCK, SKEWED_CELL_BLOCK, 1))
+    return skewed_input
+
+
+def load_benzene_case(cp2k_input: Path, dx: float, centered_positions: np.ndarray | None = None) -> Cp2kGridOrbitals:
+    cgo = Cp2kGridOrbitals(single_precision=False)
+    cgo.read_cp2k_input(cp2k_input)
+    cgo.read_xyz(XYZ_FILE)
+    if centered_positions is None:
+        cgo.center_atoms_to_cell()
+    else:
+        cgo.ase_atoms.positions[:] = centered_positions
+    cgo.read_basis_functions(BASIS_FILE)
+    cgo.load_restart_wfn_file(WFN_FILE, n_occ=1, n_virt=1)
+    cgo.calc_morbs_in_region(dx, pbc=(True, True, True), eval_cutoff=14.0, print_info=False)
+    return cgo
+
+
+def check_orthogonal_cube_generation(tmpdir: Path) -> None:
+    cgo = load_benzene_case(CP2K_INPUT, dx=0.8)
+    cube_path = tmpdir / "benzene_homo.cube"
+    cgo.write_cube(cube_path, orbital_nr=0)
+
+    cube = Cube()
+    cube.read_cube_file(cube_path)
+
+    assert cube.data.shape == (17, 17, 17), cube.data.shape
+    np.testing.assert_allclose(cube.cell, np.diag(np.diag(cube.cell)))
+    assert np.max(np.abs(cube.data)) > 1e-2
+    print("orthogonal cube generation: ok")
+
+
+def check_reciprocal_metric_reduces_to_orthogonal_formula() -> None:
+    cgo = Cp2kGridOrbitals()
+    cgo.cell_vectors = np.diag([4.0, 6.0, 10.0])
+    cgo.cell = np.linalg.norm(cgo.cell_vectors, axis=1)
+    cgo.dv = cgo.cell / np.array([8, 12, 10])
+    cgo.eval_cell_n = np.array([8, 12, 10])
+    cgo._update_grid_vectors_from_lengths()
+
+    g2_grid = cgo._surface_reciprocal_grids((8, 12))
+    kx_arr = 2 * np.pi * np.fft.fftfreq(8, cgo.dv[0])
+    ky_arr = 2 * np.pi * np.fft.rfftfreq(12, cgo.dv[1])
+    kx_grid, ky_grid = np.meshgrid(kx_arr, ky_arr, indexing="ij")
+    np.testing.assert_allclose(g2_grid, kx_grid**2 + ky_grid**2)
+    print("orthogonal reciprocal metric: ok")
+
+
+def skewed_grid_cartesian_points(cgo: Cp2kGridOrbitals) -> np.ndarray:
+    ix, iy, iz = np.meshgrid(
+        np.arange(cgo.eval_cell_n[0]),
+        np.arange(cgo.eval_cell_n[1]),
+        np.arange(cgo.eval_cell_n[2]),
+        indexing="ij",
+    )
+    points = (
+        cgo.origin
+        + ix[..., None] * cgo.dv_vectors[0]
+        + iy[..., None] * cgo.dv_vectors[1]
+        + iz[..., None] * cgo.dv_vectors[2]
+    )
+    return points.reshape(-1, 3)
+
+
+def check_skewed_grid_against_orthogonal_reference(skewed_input: Path) -> None:
+    orth = load_benzene_case(CP2K_INPUT, dx=0.35)
+    skewed = load_benzene_case(skewed_input, dx=0.35, centered_positions=orth.ase_atoms.positions.copy())
+
+    axes = [np.arange(n) * dv + origin for n, dv, origin in zip(orth.eval_cell_n, orth.dv, orth.origin)]
+    skewed_points = skewed_grid_cartesian_points(skewed)
+
+    overlap = np.ones(len(skewed_points), dtype=bool)
+    for axis, grid_axis in enumerate(axes):
+        overlap &= (skewed_points[:, axis] >= grid_axis[0]) & (skewed_points[:, axis] <= grid_axis[-1])
+
+    overlap_fraction = float(overlap.mean())
+    assert overlap_fraction > 0.9, overlap_fraction
+
+    for orbital_index in range(skewed.morb_grids[0].shape[0]):
+        interp = RegularGridInterpolator(axes, orth.morb_grids[0][orbital_index], bounds_error=False, fill_value=np.nan)
+        reference = interp(skewed_points[overlap])
+        candidate = skewed.morb_grids[0][orbital_index].reshape(-1)[overlap]
+        abs_diff = np.abs(candidate - reference)
+        ref_abs = np.abs(reference)
+        important = ref_abs > max(1e-5, 1e-3 * np.nanmax(ref_abs))
+
+        p95 = np.nanpercentile(abs_diff, 95)
+        p99 = np.nanpercentile(abs_diff, 99)
+        rms_important = np.sqrt(np.nanmean(abs_diff[important] ** 2))
+
+        assert p95 < 2e-4, (orbital_index, p95)
+        assert p99 < 2e-3, (orbital_index, p99)
+        assert rms_important < 3e-3, (orbital_index, rms_important)
+
+        print(
+            f"skewed orbital {orbital_index}: ok "
+            f"(overlap={overlap_fraction:.3f}, p95={p95:.3e}, p99={p99:.3e}, rms={rms_important:.3e})"
+        )
+
+
+def check_skewed_cube_cell_vectors(tmpdir: Path, skewed_input: Path) -> None:
+    cgo = load_benzene_case(skewed_input, dx=0.8)
+    cube_path = tmpdir / "benzene_skewed_homo.cube"
+    cgo.write_cube(cube_path, orbital_nr=0)
+
+    cube = Cube()
+    cube.read_cube_file(cube_path, read_data=False)
+    np.testing.assert_allclose(cube.cell, cgo.eval_cell_vectors, atol=5e-5)
+    assert abs(cube.cell[1, 0]) > 1e-6
+    print("skewed cube cell vectors: ok")
+
+
+def main() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir_str:
+        tmpdir = Path(tmpdir_str)
+        skewed_input = make_skewed_input(tmpdir)
+        check_orthogonal_cube_generation(tmpdir)
+        check_reciprocal_metric_reduces_to_orthogonal_formula()
+        check_skewed_grid_against_orthogonal_reference(skewed_input)
+        check_skewed_cube_cell_vectors(tmpdir, skewed_input)
+    print("skewed-cell validation passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/validate_skewed_cell_support.py
+++ b/examples/validate_skewed_cell_support.py
@@ -18,6 +18,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT))
 
 from cp2k_spm_tools.cp2k_grid_orbitals import Cp2kGridOrbitals  # noqa: E402
+from cp2k_spm_tools.cp2k_stm_sts import STM  # noqa: E402
 from cp2k_spm_tools.cube import Cube  # noqa: E402
 
 DATA_DIR = REPO_ROOT / "examples" / "data"
@@ -92,6 +93,30 @@ def check_reciprocal_metric_reduces_to_orthogonal_formula() -> None:
     print("orthogonal reciprocal metric: ok")
 
 
+def check_skewed_p_tip_gradient_metric() -> None:
+    dv_vectors = np.array(
+        [
+            [0.5, 0.0, 0.0],
+            [0.2, 0.4, 0.0],
+            [0.0, 0.0, 0.7],
+        ]
+    )
+    dv = np.linalg.norm(dv_vectors, axis=1)
+    grad_expected = np.array([1.7, -0.9])
+
+    ix, iy = np.meshgrid(np.arange(12), np.arange(14), indexing="ij")
+    x = ix * dv_vectors[0, 0] + iy * dv_vectors[1, 0]
+    y = ix * dv_vectors[0, 1] + iy * dv_vectors[1, 1]
+    orbital = (grad_expected[0] * x + grad_expected[1] * y)[None, :, :, None]
+
+    d_axis0 = np.gradient(orbital, axis=1)
+    d_axis1 = np.gradient(orbital, axis=2)
+    p_tip_contrib = STM.in_plane_gradient_squared(d_axis0, d_axis1, dv, dv_vectors)
+
+    np.testing.assert_allclose(p_tip_contrib, np.dot(grad_expected, grad_expected), atol=1e-12)
+    print("skewed p-tip gradient metric: ok")
+
+
 def skewed_grid_cartesian_points(cgo: Cp2kGridOrbitals) -> np.ndarray:
     ix, iy, iz = np.meshgrid(
         np.arange(cgo.eval_cell_n[0]),
@@ -162,6 +187,7 @@ def main() -> None:
         skewed_input = make_skewed_input(tmpdir)
         check_orthogonal_cube_generation(tmpdir)
         check_reciprocal_metric_reduces_to_orthogonal_formula()
+        check_skewed_p_tip_gradient_metric()
         check_skewed_grid_against_orthogonal_reference(skewed_input)
         check_skewed_cube_cell_vectors(tmpdir, skewed_input)
     print("skewed-cell validation passed")


### PR DESCRIPTION
## Summary

This draft adds initial support for skewed in-plane CP2K SPM cells in the WFN gridding path.

The implementation keeps the existing orthogonal-cell behavior intact while introducing full cell-vector handling for slab-like cells where `A` and `B` lie in the xy plane and `C` is along z. More general tilted/triclinic cells are deliberately rejected for now instead of being treated incorrectly.

This PR is stacked on top of #20 (`codex/numpy2-compat`) and should be retargeted to `main` after #20 is merged.

## Changes

- Parse CP2K `A`, `B`, and `C` cell vectors without requiring a rectangular cell.
- Store full cell vectors alongside the existing cell-vector lengths used by older code paths.
- Convert atom positions through fractional/grid coordinates before placing local orbital grids.
- Evaluate radial functions and solid harmonics in Cartesian coordinates on skewed grids.
- Use the in-plane reciprocal metric for FFT extrapolation instead of assuming `kx**2 + ky**2`.
- Write CUBE files with the full evaluation-cell matrix and integrate densities using the voxel determinant.
- Convert p-tip finite-difference derivatives from lattice-axis derivatives to Cartesian in-plane gradients.
- Save skewed-cell metadata in STM/orbital `.npz` outputs.
- Add `examples/validate_skewed_cell_support.py` for lightweight manual validation with bundled benzene data.

## Validation

- `python -m py_compile cp2k_spm_tools/cp2k_grid_orbitals.py cp2k_spm_tools/cp2k_stm_sts.py examples/validate_skewed_cell_support.py`
- `git diff --check`
- `PYTHONPATH=/home/jovyan/opt/cp2k-spm-tools python examples/validate_skewed_cell_support.py`
- `pre-commit run --files cp2k_spm_tools/cp2k_grid_orbitals.py cp2k_spm_tools/cp2k_stm_sts.py examples/validate_skewed_cell_support.py`

Additional local check: the standard orthogonal benzene CUBE output was compared against the base NumPy-2 branch and matched exactly for HOMO and LUMO.

## Still To Test

- Real non-90-degree CP2K/SPM calculations from production-like inputs.
- Plotting behavior for skewed STM/orbital maps.
- HRSTM-specific paths, which still contain additional rectangular-grid assumptions and are not claimed as fixed here.
