### PR TITLE
Store the parsed matrix in Cp2kOverlapMatrix.read_ascii_csr

### DIFF
--- a/cp2k_spm_tools/cp2k_overlap_matrix.py
+++ b/cp2k_spm_tools/cp2k_overlap_matrix.py
@@ -7,9 +7,7 @@ hart_2_ev = 27.21138602
 
 
 class Cp2kOverlapMatrix:
-    """
-    Class to deal with the CP2K overlap matrix
-    """
+    """Class to deal with the CP2K overlap matrix"""
 
     def __init__(self):
         self.sparse_mat = None
@@ -28,3 +26,4 @@ class Cp2kOverlapMatrix:
 
         # diagonal got added by both triangular sides
         sparse_mat.setdiag(sparse_mat.diagonal() / 2)
+        self.sparse_mat = sparse_mat

--- a/tests/test_cp2k_overlap_matrix.py
+++ b/tests/test_cp2k_overlap_matrix.py
@@ -1,0 +1,16 @@
+from cp2k_spm_tools.cp2k_overlap_matrix import Cp2kOverlapMatrix
+
+
+def test_read_ascii_csr_populates_symmetric_sparse_mat(tmp_path):
+    csr_file = tmp_path / "overlap.csr"
+    csr_file.write_text("1 1 1.0\n1 2 0.25\n2 2 1.0\n")
+
+    overlap_matrix = Cp2kOverlapMatrix()
+    overlap_matrix.read_ascii_csr(str(csr_file), n_basis_f=2)
+
+    assert overlap_matrix.sparse_mat is not None
+    assert overlap_matrix.sparse_mat.shape == (2, 2)
+
+    dense = overlap_matrix.sparse_mat.toarray()
+    assert dense[0, 1] == dense[1, 0] == 0.25
+    assert dense[0, 0] == 1.0


### PR DESCRIPTION
Why: read_ascii_csr built a sparse matrix but never assigned it,
so self.sparse_mat stayed `None`. In this PR, we assign the
completed matrix to self.sparse_mat at the end of the method.
