### PR TITLE
Require Python 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up Python 3.10
+      - name: Set up Python 3.12
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.12"
           cache: "pip"
           cache-dependency-path: |
             pyproject.toml
@@ -46,10 +46,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up Python 3.10
+      - name: Set up Python 3.12
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.12"
           cache: "pip"
           cache-dependency-path: |
             pyproject.toml

--- a/.github/workflows/release_and_publish.yml
+++ b/.github/workflows/release_and_publish.yml
@@ -16,10 +16,10 @@
         - name: Checkout code
           uses: actions/checkout@v3
   
-        - name: Set up Python 3.10
+        - name: Set up Python 3.12
           uses: actions/setup-python@v5
           with:
-            python-version: "3.10"
+            python-version: "3.12"
         
         - name: Install MPICH
           run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 ]
 readme = "README.md"
 license = { file = "LICENSE" }
-requires-python = ">=3.8"
+requires-python = ">=3.12"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
## Why

The package currently advertises Python >=3.8 while CI and release jobs use 3.10. These versions are not supported or tested in the EMPA AiiDAlab environment, whose baseline is Python 3.12, so the metadata currently promises compatibility we do not maintain.

## Changes

- set `requires-python = ">=3.12"`
- run CI and release builds on Python 3.12

No runtime dependency versions are changed.

## Validation

Python 3.12.11: `pytest -q`, `pre-commit run --all-files`, metadata/workflow parsing, and `git diff --check` passed.

Prepared with Codex.