### PR TITLE
Warn when parsed AO indices have gaps

### DIFF
--- a/cp2k_spm_tools/cp2k_overlap_matrix.py
+++ b/cp2k_spm_tools/cp2k_overlap_matrix.py
@@ -80,7 +80,8 @@ def parse_cp2k_overlap_matrix_log_data(
 
     Warns:
         UserWarning: If unexpected lines were skipped between the title and the
-            first data row, which may indicate an unrecognised output format.
+            first data row, which may indicate an unrecognised output format, or
+            if the parsed AO indices have gaps, leaving empty metadata rows.
     """
 
     path = Path(path)
@@ -176,6 +177,19 @@ def parse_cp2k_overlap_matrix_log_data(
 
     if not basis:
         raise ValueError(f"No overlap-matrix entries found in {path}")
+
+    # Rows are filled in only where the log actually had a data row, so a gap
+    # leaves atom_index 0 and empty element/orbital strings for that AO.
+    missing = sorted(set(range(max_index)) - basis.keys())
+    if missing:
+        shown = ", ".join(str(index + 1) for index in missing[:10])
+        if len(missing) > 10:
+            shown += f", ... ({len(missing)} total)"
+        warnings.warn(
+            f"No overlap data row for AO index {shown} in {path}; "
+            f"their atom, element and orbital metadata will be empty",
+            stacklevel=2,
+        )
 
     matrix = sp.coo_matrix((vals, (rows, cols)), shape=(max_index, max_index)).tocsr()
     basis_index = np.arange(1, max_index + 1, dtype=np.int64)

--- a/tests/test_overlap_to_sparse_npz.py
+++ b/tests/test_overlap_to_sparse_npz.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from pathlib import Path
 
 import numpy as np
@@ -105,6 +106,31 @@ def test_parse_warns_on_unexpected_preamble_lines(tmp_path):
 
     with pytest.warns(UserWarning, match="Skipped 1 unexpected line"):
         assert_parses_like_reference_log(path)
+
+
+def test_parse_warns_on_missing_ao_rows(tmp_path):
+    log = write_log(
+        tmp_path,
+        " OVERLAP MATRIX\n"
+        "              1              2              3\n"
+        "      1       1 C  s       1.000000D+00   0.000000D+00   0.000000D+00\n"
+        "      3       2 H  s       0.000000D+00   0.000000D+00   1.000000D+00\n",
+    )
+
+    with pytest.warns(UserWarning, match="No overlap data row for AO index 2"):
+        parsed = parse_cp2k_overlap_matrix_log_data(log)
+
+    assert parsed.matrix.shape == (3, 3)
+    assert parsed.atom_index[1] == 0
+    assert parsed.element[1] == ""
+
+
+def test_parse_does_not_warn_on_complete_log():
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        parse_cp2k_overlap_matrix_log_data(OVERLAP_LOG)
+
+    assert caught == []
 
 
 def test_parse_threshold_preserves_shape_and_metadata():

--- a/tests/test_overlap_to_sparse_npz.py
+++ b/tests/test_overlap_to_sparse_npz.py
@@ -125,6 +125,22 @@ def test_parse_warns_on_missing_ao_rows(tmp_path):
     assert parsed.element[1] == ""
 
 
+def test_parse_warns_on_multiple_missing_ao_rows(tmp_path):
+    log = write_log(
+        tmp_path,
+        " OVERLAP MATRIX\n"
+        "              1              2              3              4\n"
+        "      1       1 C  s       1.000000D+00   0.000000D+00   0.000000D+00   0.000000D+00\n"
+        "      4       2 H  s       0.000000D+00   0.000000D+00   0.000000D+00   1.000000D+00\n",
+    )
+
+    with pytest.warns(UserWarning, match=r"No overlap data row for AO index 2, 3\b"):
+        parsed = parse_cp2k_overlap_matrix_log_data(log)
+
+    assert parsed.matrix.shape == (4, 4)
+    assert parsed.atom_index[1] == 0 and parsed.atom_index[2] == 0
+
+
 def test_parse_warns_on_many_missing_ao_rows_truncates_message(tmp_path):
     """The warning lists at most 10 missing indices, then a total count."""
 

--- a/tests/test_overlap_to_sparse_npz.py
+++ b/tests/test_overlap_to_sparse_npz.py
@@ -125,6 +125,23 @@ def test_parse_warns_on_missing_ao_rows(tmp_path):
     assert parsed.element[1] == ""
 
 
+def test_parse_warns_on_many_missing_ao_rows_truncates_message(tmp_path):
+    """The warning lists at most 10 missing indices, then a total count."""
+
+    n_cols = 15
+    header = " ".join(str(i) for i in range(1, n_cols + 1))
+    values = " ".join("1.000000D+00" if i == 0 else "0.000000D+00" for i in range(n_cols))
+    log = write_log(
+        tmp_path,
+        f" OVERLAP MATRIX\n{header}\n      1       1 C  s       {values}\n",
+    )
+
+    with pytest.warns(UserWarning, match=r"\.\.\. \(14 total\)"):
+        parsed = parse_cp2k_overlap_matrix_log_data(log)
+
+    assert parsed.matrix.shape == (n_cols, n_cols)
+
+
 def test_parse_does_not_warn_on_complete_log():
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")


### PR DESCRIPTION
The parser sizes the matrix from the largest AO index seen but only fills metadata for rows it actually parsed, so a missing data row left a silent hole (atom_index 0, empty element/orbital) that downstream per-atom grouping would drop rather than flag. Warn with the missing 1-based indices (capped at ten) instead, matching the existing skipped-line warning. No change to shapes, values, or the NPZ format.

fixes #28 